### PR TITLE
Add textarea scrolling via Ctrl-e/y/d/u in normal and visual modes

### DIFF
--- a/dist/tampermonkey_vim_mode.js
+++ b/dist/tampermonkey_vim_mode.js
@@ -716,6 +716,28 @@
             }
             return pos;
         }
+        function scrollTextarea(currentInput, lines) {
+            const computedStyle = window.getComputedStyle(currentInput);
+            const lineHeight = parseFloat(computedStyle.lineHeight);
+            const fontSize = parseFloat(computedStyle.fontSize);
+            const effectiveLineHeight = isNaN(lineHeight)
+                ? fontSize * 1.2
+                : lineHeight;
+            currentInput.scrollTop += lines * effectiveLineHeight;
+        }
+        function scrollHalfPage(currentInput, down) {
+            const computedStyle = window.getComputedStyle(currentInput);
+            const lineHeight = parseFloat(computedStyle.lineHeight);
+            const fontSize = parseFloat(computedStyle.fontSize);
+            const effectiveLineHeight = isNaN(lineHeight)
+                ? fontSize * 1.2
+                : lineHeight;
+            const visibleHeight = currentInput.clientHeight;
+            const halfPageLines = Math.floor(
+                visibleHeight / effectiveLineHeight / 2,
+            );
+            scrollTextarea(currentInput, down ? halfPageLines : -halfPageLines);
+        }
         function isWordChar(char) {
             return /\w/.test(char);
         }
@@ -2377,11 +2399,31 @@
                 debug("handleKeyDown: insert mode, passing through");
                 return;
             }
-            debug("handleKeyDown: normal mode, processing command");
+            debug("handleKeyDown: normal/visual mode, processing command");
             e.preventDefault();
             if (e.ctrlKey && e.key === "r") {
                 debug("handleKeyDown: Ctrl-r redo");
                 redo(currentInput, undoStack, redoStack);
+                return;
+            }
+            if (e.ctrlKey && e.key === "e") {
+                debug("handleKeyDown: Ctrl-e scroll down one line");
+                scrollTextarea(currentInput, 1);
+                return;
+            }
+            if (e.ctrlKey && e.key === "y") {
+                debug("handleKeyDown: Ctrl-y scroll up one line");
+                scrollTextarea(currentInput, -1);
+                return;
+            }
+            if (e.ctrlKey && e.key === "d") {
+                debug("handleKeyDown: Ctrl-d scroll down half page");
+                scrollHalfPage(currentInput, true);
+                return;
+            }
+            if (e.ctrlKey && e.key === "u") {
+                debug("handleKeyDown: Ctrl-u scroll up half page");
+                scrollHalfPage(currentInput, false);
                 return;
             }
             processCommand(e.key);

--- a/src/common.ts
+++ b/src/common.ts
@@ -707,6 +707,38 @@ export function getFirstNonBlank(
     return pos;
 }
 
+// Scrolling functions
+export function scrollTextarea(
+    currentInput: EditableElement,
+    lines: number,
+): void {
+    // Calculate line height from element styles
+    const computedStyle = window.getComputedStyle(currentInput);
+    const lineHeight = parseFloat(computedStyle.lineHeight);
+    const fontSize = parseFloat(computedStyle.fontSize);
+    const effectiveLineHeight = isNaN(lineHeight) ? fontSize * 1.2 : lineHeight;
+
+    // Scroll by the calculated pixel amount
+    currentInput.scrollTop += lines * effectiveLineHeight;
+}
+
+export function scrollHalfPage(
+    currentInput: EditableElement,
+    down: boolean,
+): void {
+    const computedStyle = window.getComputedStyle(currentInput);
+    const lineHeight = parseFloat(computedStyle.lineHeight);
+    const fontSize = parseFloat(computedStyle.fontSize);
+    const effectiveLineHeight = isNaN(lineHeight) ? fontSize * 1.2 : lineHeight;
+
+    // Calculate visible lines (half page)
+    const visibleHeight = currentInput.clientHeight;
+    const halfPageLines = Math.floor(visibleHeight / effectiveLineHeight / 2);
+
+    // Scroll by half page
+    scrollTextarea(currentInput, down ? halfPageLines : -halfPageLines);
+}
+
 export function isWordChar(char: string): boolean {
     return /\w/.test(char);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import {
     clearVisualSelection,
     updateLineNumbers,
     removeLineNumbers,
+    scrollTextarea,
+    scrollHalfPage,
 } from "./common.js";
 import { processNormalCommand } from "./normal.js";
 import { processVisualCommand, updateVisualSelection } from "./visual.js";
@@ -395,16 +397,43 @@ function handleKeyDown(e: KeyboardEvent): void {
         return;
     }
 
-    // Normal mode
-    debug("handleKeyDown: normal mode, processing command");
+    // Normal/Visual mode commands that work in both modes
+    debug("handleKeyDown: normal/visual mode, processing command");
     e.preventDefault();
 
+    // Redo (works in both normal and visual modes)
     if (e.ctrlKey && e.key === "r") {
         debug("handleKeyDown: Ctrl-r redo");
         redo(currentInput, undoStack, redoStack);
         return;
     }
 
+    // Scrolling commands (work in both normal and visual modes)
+    if (e.ctrlKey && e.key === "e") {
+        debug("handleKeyDown: Ctrl-e scroll down one line");
+        scrollTextarea(currentInput, 1);
+        return;
+    }
+
+    if (e.ctrlKey && e.key === "y") {
+        debug("handleKeyDown: Ctrl-y scroll up one line");
+        scrollTextarea(currentInput, -1);
+        return;
+    }
+
+    if (e.ctrlKey && e.key === "d") {
+        debug("handleKeyDown: Ctrl-d scroll down half page");
+        scrollHalfPage(currentInput, true);
+        return;
+    }
+
+    if (e.ctrlKey && e.key === "u") {
+        debug("handleKeyDown: Ctrl-u scroll up half page");
+        scrollHalfPage(currentInput, false);
+        return;
+    }
+
+    // Mode-specific command handling
     processCommand(e.key);
 }
 


### PR DESCRIPTION
Implement scrolling commands for textareas and inputs:
- Ctrl-e: scroll down one line
- Ctrl-y: scroll up one line
- Ctrl-d: scroll down half page
- Ctrl-u: scroll up half page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
